### PR TITLE
Fixing "#3: Invalid Credentials"

### DIFF
--- a/sprintly
+++ b/sprintly
@@ -552,7 +552,7 @@ class SprintlyTool:
         url = 'https://sprint.ly/api/%s' % url
 
         try:
-            userData = 'Basic ' + (self._config['user'] + ':' + self._config['key']).encode('base64').rstrip()
+            userData = 'Basic ' + (self._config['user'] + ':' + self._config['key']).encode('base64').replace("\n",'')
             req = urllib2.Request(url)
             req.add_header('Accept', 'application/json')
             req.add_header('Authorization', userData)


### PR DESCRIPTION
By default encode("base64") adds "\n" after every 76 characters, so
longer email addresses were resulting in "\n" characters in the
userData, which sprintly doesn't handle.

Simply removing all "\n" characters should fix issue #3 (my email/api key combination did contain 80 characters and this fix now allow me to authenticate properly).
