### PR TITLE
Fixing broken configuration update in smaller terminals or with long product lists.

### DIFF
--- a/sprintly
+++ b/sprintly
@@ -255,7 +255,7 @@ class SprintlyTool:
         # used to simplify prompting user with optional default
         def getConfigItem(message, default=None):
             if default:
-                item = raw_input(self.render('%s [${YELLOW}%s${RESET}]: ' % (message, default))) or default
+                item = raw_input(self.render('%s [${YELLOW}%s${RESET}]: ' % (message, default), trim=False)) or default
             else:
                 item = raw_input('%s: ' % message)
             return item


### PR DESCRIPTION
This bug was causing the configuration update prompts to be truncated, which caused raw_input to choke on the non-ASCII horizontal ellipsis. By not trimming to the width of the terminal, we avoid this case, and fix the config update code.
