### PR TITLE
Fixed breaking issue with items moved from backlog to someday

### DIFF
--- a/sprintly
+++ b/sprintly
@@ -379,6 +379,8 @@ class SprintlyTool:
 
         for product in products:
             for item in product['items']:
+                if item['status'] == 'someday':
+                    continue
                 if not product['id'] in statusTree[item['status']]:
                     statusTree[item['status']][product['id']] = []
 


### PR DESCRIPTION
When moving an item with sub-tasks from backlog to someday, the pre-commit hook breaks as it doesn't support 'someday' as a status. This is probably a symptom bigger issue with the sprint.ly status code, but this change will at least fix the problem for the pre-commit hook.
