### PR TITLE
Shorten Commit Message

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -36,7 +36,7 @@ def process(commit_msg_path):
             return
 
         # convert items into string
-        items_string = ' '.join(map(lambda x: 'References #' + str(x) + '.', items))
+        items_string = ' '.join(map(lambda x: 'Re #' + str(x) + '.', items))
 
         # create new commit message
         new_commit_msg = items_string + ' ' + commit_msg


### PR DESCRIPTION
The subject line of a git commit message is 50 chars, the word "references" is 10, which means the current code uses 20% of the subject line per issue referenced before you can even get to meat of your subject line. Shortening to "re" allows the user to tag multiple issues in a commit and still squeeze in a meaningful subject.
