### PR TITLE
Fixing #39 - Both 'sprintly' and 'commit-msg' are now Python 2/3 compatible

### DIFF
--- a/commit-msg
+++ b/commit-msg
@@ -4,6 +4,7 @@ import sys
 import re
 import os
 import subprocess
+from builtins import input
 
 
 def process(commit_msg_path):
@@ -32,7 +33,7 @@ def process(commit_msg_path):
 
         # check if they opted out
         if '0' in items:
-            print 'Proceeding without Sprint.ly item number.'
+            print('Proceeding without Sprint.ly item number.')
             return
 
         # convert items into string
@@ -87,9 +88,9 @@ def display_sprintly_items():
     try:
         subprocess.call(['sprintly'], stdin=open('/dev/tty', 'r'))
     except:
-        print 'Command-line tool \'sprintly\' not found. Please ensure it is installed and on your path.'
+        print('Command-line tool \'sprintly\' not found. Please ensure it is installed and on your path.')
 
-    print '#0 - Proceed without Sprint.ly item number.'
+    print('#0 - Proceed without Sprint.ly item number.')
 
 
 def get_sprintly_items():
@@ -104,7 +105,7 @@ def get_sprintly_items():
     sys.stdin = open('/dev/tty', 'r')
 
     while True:
-        sprintly_items = raw_input('Enter 1 or more item numbers separated by a space: ').split(' ')
+        sprintly_items = input('Enter 1 or more item numbers separated by a space: ').split(' ')
         result = map(lambda x: parse_item_number(x), sprintly_items)
         if not None in result:
             return result
@@ -129,10 +130,10 @@ if __name__ == '__main__':
             # Should never happen, but just in case...
             raise Exception('Commit message was not received.')
     except KeyboardInterrupt:
-        print '\n\nProgram interrupted. Commit aborted.'
+        print('\n\nProgram interrupted. Commit aborted.')
         sys.exit(1)
     except Exception as e:
-        print '\n\nError occurred. Commit aborted.'
+        print('\n\nError occurred. Commit aborted.')
         sys.exit(1)
 
     # Execute the original commit hook. Note: We don't want realpath because
@@ -140,6 +141,6 @@ if __name__ == '__main__':
     # .git/hooks/commit-msg and we want to be in the hooks directory.
     original_commit_msg = os.path.dirname(__file__) + '/commit-msg.original'
     if os.path.exists(original_commit_msg):
-      sys.exit(subprocess.call([original_commit_msg, sys.argv[1]]))
+        sys.exit(subprocess.call([original_commit_msg, sys.argv[1]]))
     else:
-      sys.exit(0)
+        sys.exit(0)

--- a/sprintly
+++ b/sprintly
@@ -167,12 +167,11 @@ class SprintlyTool:
         print('Downloading latest version of sprintly from GitHub...')
 
         # get the file
-        # try:
-        #     response = urlopen(SPRINTLY_SOURCE_URL)
-        #     sprintly_file_contents = response.read()
-        # except Exception:
-        #     raise SprintlyException('Unable to obtain commit-msg from %s' % SPRINTLY_SOURCE_URL)
-        sprintly_file_contents = open(__file__, 'r').read()
+        try:
+            response = urlopen(SPRINTLY_SOURCE_URL)
+            sprintly_file_contents = response.read()
+        except Exception:
+            raise SprintlyException('Unable to obtain commit-msg from %s' % SPRINTLY_SOURCE_URL)
 
         # verify nothing exists at the target path
         target = SPRINTLY_PATH

--- a/sprintly
+++ b/sprintly
@@ -1,23 +1,35 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 
+import base64
 import sys
 import os
 import locale
-import urllib2
 import json
 import shutil
 import subprocess
 import re
 import string
 import logging
+from builtins import bytes, input
 from curses import setupterm, tigetstr, tigetnum, tparm
+from imp import reload
 from time import time
 from optparse import OptionParser
 
+# Python 2/3 urllib compatibility
+try:
+    from urllib.error import HTTPError
+    from urllib.request import urlopen, Request
+except ImportError:  # possibly Python 2?
+    from urllib2 import HTTPError, Request, urlopen
+
 # force utf-8 encoding
-reload(sys)
-sys.setdefaultencoding('utf-8')
+if sys.getdefaultencoding() != 'utf-8':
+    reload(sys)
+    # this method doesn't exist in Python 3, but that's ok...
+    # Python 3 is by default utf-8, so we shouldn't get here in Python 3
+    sys.setdefaultencoding('utf-8')
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -61,6 +73,7 @@ ITEM_STATUSES = {
     'completed': "Completed",
     'accepted': "Accepted",
 }
+
 
 class SprintlyTool:
     """
@@ -151,28 +164,29 @@ class SprintlyTool:
         exists with the same name, user will be prompted to replace the file.
         """
 
-        print 'Downloading latest version of sprintly from GitHub...'
+        print('Downloading latest version of sprintly from GitHub...')
 
         # get the file
-        try:
-            response = urllib2.urlopen(SPRINTLY_SOURCE_URL)
-            sprintly_file_contents = response.read()
-        except Exception:
-            raise SprintlyException('Unable to obtain commit-msg from %s' % SPRINTLY_SOURCE_URL)
+        # try:
+        #     response = urlopen(SPRINTLY_SOURCE_URL)
+        #     sprintly_file_contents = response.read()
+        # except Exception:
+        #     raise SprintlyException('Unable to obtain commit-msg from %s' % SPRINTLY_SOURCE_URL)
+        sprintly_file_contents = open(__file__, 'r').read()
 
         # verify nothing exists at the target path
         target = SPRINTLY_PATH
         if os.path.isfile(target):
-            overwrite = raw_input(self.render('${BRIGHT_YELLOW}A file already exists at %s.${RESET} Overwrite file? ' % target, trim=False))
+            overwrite = input(self.render('${BRIGHT_YELLOW}A file already exists at %s.${RESET} Overwrite file? ' % target, trim=False))
             while overwrite != 'y' and overwrite != 'n':
-                overwrite = raw_input('Please enter y/n: ')
+                overwrite = input('Please enter y/n: ')
 
             if overwrite == 'n':
                 self.cprint('Unable to install. Please install manually.', attr=RED)
                 return
 
             # remove existing file
-            print 'Deleting %s...' % target
+            print('Deleting %s...' % target)
             try:
                 os.unlink(target)
             except Exception:
@@ -202,9 +216,9 @@ class SprintlyTool:
 
         # if this is not an update, install
         if not update:
-            print ''
+            print('')
             self.cprint('That\'s all! Type \'sprintly\' and hit enter to get started.', attr=BRIGHT_MAGENTA)
-            print ''
+            print('')
 
     def initialize(self):
         """
@@ -222,7 +236,7 @@ class SprintlyTool:
         # set the sprintly directory path (create if it doesn't exist)
         self._sprintlyDirectoryPath = os.path.join(home, '.sprintly')
         if not os.path.isdir(self._sprintlyDirectoryPath):
-            os.mkdir(self._sprintlyDirectoryPath, 0700)
+            os.mkdir(self._sprintlyDirectoryPath, 0o700)
             if not os.path.isdir(self._sprintlyDirectoryPath):
                 raise SprintlyException('Unable to create folder at %s' % self._sprintlyDirectoryPath)
 
@@ -256,9 +270,9 @@ class SprintlyTool:
         """
 
         if not update:
-            print 'Creating config...'
+            print('Creating config...')
         else:
-            print 'Updating config... Press enter to accept default value shown in brackets.'
+            print('Updating config... Press enter to accept default value shown in brackets.')
 
         # set version
         self._config['version'] = CONFIG_VERSION
@@ -266,9 +280,9 @@ class SprintlyTool:
         # used to simplify prompting user with optional default
         def getConfigItem(message, default=None):
             if default:
-                item = raw_input(self.render('%s [${YELLOW}%s${RESET}]: ' % (message, default), trim=False)) or default
+                item = input(self.render('%s [${YELLOW}%s${RESET}]: ' % (message, default), trim=False)) or default
             else:
-                item = raw_input('%s: ' % message)
+                item = input('%s: ' % message)
             return item
 
         # prompt for user
@@ -483,15 +497,15 @@ class SprintlyTool:
                     message = ''
                     if 'message' in items:
                         message = ': %s' % items['message']
-                    print 'Warning: unable to get items for %s%s' % (productNameWithUrl, message)
+                    print('Warning: unable to get items for %s%s' % (productNameWithUrl, message))
                     continue
                 # if there are no items, display message
                 elif len(items) == 0:
-                    print 'No assigned items for %s' % (productNameWithUrl)
+                    print('No assigned items for %s' % (productNameWithUrl))
                 # a 'parent' is any item without a parent key
                 # a 'child' is any item with a parent key
                 # sort so that all parents appear first and all children appear after ordered by their number
-                items.sort(key=lambda item: item['number'] if 'parent' in item else sys.maxint, reverse=True)
+                items.sort(key=lambda item: item['number'] if 'parent' in item else sys.maxsize, reverse=True)
 
                 # turn flat list into tree
                 itemsTree = []
@@ -537,9 +551,9 @@ class SprintlyTool:
             cache_file.write(serialized_cache)
             cache_file.close()
         except Exception:
-            print '\033[91m'
-            print 'Unable to populate cache. List may not be up to date.'
-            print '\033[0m'
+            print('\033[91m')
+            print('Unable to populate cache. List may not be up to date.')
+            print('\033[0m')
 
     def readCache(self):
         """
@@ -566,14 +580,15 @@ class SprintlyTool:
         url = 'https://sprint.ly/api/%s' % url
 
         try:
-            userData = 'Basic ' + (self._config['user'] + ':' + self._config['key']).encode('base64').replace("\n",'')
-            req = urllib2.Request(url)
+            b64_key = base64.b64encode(bytes(self._config['user'] + ':' + self._config['key'], 'utf-8')).decode('utf-8').replace("\n", '')
+            userData = 'Basic ' + b64_key
+            req = Request(url)
             req.add_header('Accept', 'application/json')
             req.add_header('Authorization', userData)
-            res = urllib2.urlopen(req)
+            res = urlopen(req)
             response = res.read()
-            return json.loads(response)
-        except urllib2.HTTPError, error:
+            return json.loads(response.decode('utf-8'))
+        except HTTPError as error:
             response = error.read()
             return json.loads(response)
         except Exception:
@@ -609,14 +624,14 @@ class SprintlyTool:
         except Exception:
             raise SprintlyException('File already exists at %s. Please delete it before proceeding.' % destination)
 
-        print 'Creating symlink...'
+        print('Creating symlink...')
 
         try:
             os.symlink(HOOK_PATH, destination)
         except Exception:
             raise SprintlyException('Unable to create symlink.')
 
-        print 'Hook was installed at %s' % destination
+        print('Hook was installed at %s' % destination)
 
         # check to see if the email associated with git matches the Sprint.ly email
         # if not, Sprint.ly won't be able to create comments
@@ -624,12 +639,12 @@ class SprintlyTool:
             process = subprocess.Popen(['git', 'config', 'user.email'], stdout=subprocess.PIPE)
             gitEmail = process.stdout.read().strip()
             if gitEmail != self._config['user']:
-                print 'WARNING: Your git email (' + gitEmail + ') does not match your Sprint.ly username (' + self._config['user'] + ')'
-                print 'WARNING: Don\'t worry - there is an easy fix. Simply run one of the following:'
-                print '\t\'git config --global user.email ' + self._config['user'] + '\' (all repos)'
-                print '\t\'git config user.email ' + self._config['user'] + '\' (this repo only)'
+                print('WARNING: Your git email (' + gitEmail + ') does not match your Sprint.ly username (' + self._config['user'] + ')')
+                print('WARNING: Don\'t worry - there is an easy fix. Simply run one of the following:')
+                print('\t\'git config --global user.email ' + self._config['user'] + '\' (all repos)')
+                print('\t\'git config user.email ' + self._config['user'] + '\' (this repo only)')
         except Exception:
-            print 'Unable to verify that \'git config user.email\' matches your Sprint.ly account email.'
+            print('Unable to verify that \'git config user.email\' matches your Sprint.ly account email.')
 
     def uninstallHook(self):
         """
@@ -652,14 +667,14 @@ class SprintlyTool:
             elif os.path.islink(destination):
                 os.unlink(destination)
             else:
-                print 'Hook is already uninstalled.'
+                print('Hook is already uninstalled.')
                 return
         except SprintlyException as e:
             raise e
         except Exception:
             raise SprintlyException('File already exists at %s. Please delete it before proceeding.' % destination)
 
-        print 'Hook has been uninstalled.'
+        print('Hook has been uninstalled.')
 
     def updateHook(self):
         """
@@ -668,11 +683,11 @@ class SprintlyTool:
         Returns the path of the file.
         """
 
-        print 'Downloading latest version of commit-msg hook from GitHub...'
+        print('Downloading latest version of commit-msg hook from GitHub...')
 
         # get the file
         try:
-            response = urllib2.urlopen(COMMIT_MSG_SOURCE_URL)
+            response = urlopen(COMMIT_MSG_SOURCE_URL)
             commit_msg_file_contents = response.read()
         except Exception:
             raise SprintlyException('Unable to obtain commit-msg from %s' % COMMIT_MSG_SOURCE_URL)
@@ -680,7 +695,7 @@ class SprintlyTool:
         # ensure directory exists
         try:
             if not os.path.exists(HOOK_DIR):
-                os.makedirs(HOOK_DIR, 0777)
+                os.makedirs(HOOK_DIR, 0o777)
         except Exception:
             raise SprintlyException('Unable to create directory %s' % HOOK_DIR)
 
@@ -694,7 +709,7 @@ class SprintlyTool:
 
         # make sure user can read, write, and execute
         try:
-            os.chmod(HOOK_PATH, 0777)
+            os.chmod(HOOK_PATH, 0o777)
         except Exception:
             raise SprintlyException('Unable to make %s executable.' % HOOK_PATH)
 
@@ -775,8 +790,9 @@ def die(message=None, *args):
 
     if message:
         logger.error(message, *args, exc_info=True)
-    print 'Program exiting.'
+    print('Program exiting.')
     sys.exit(1)
+
 
 if __name__ == '__main__':
     sprintlyTool = SprintlyTool()


### PR DESCRIPTION
**Tested both scripts with Python 2 and Python 3** 

Changelog:
- `print` statements changed to `print()` in both scripts
- `raw_input` changed to use `builtins.input`
- `reload` statement imported from `imp` module
- `sys.setdefaultencoding()` called only if not already UTF-8 (Python 2)
- conditional import of urllib items (Py3 and Py2 import from different places) - `sys.maxint` is now `sys.maxsize`
- octals are rewritten to use "0o" syntax
- base64 encoding is provided by the `base64` module
- `bytes` method replaced with `builtins.bytes`